### PR TITLE
Adds dynamic config file location functionality and improves test coverage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"encoding/json"
-	"log"
+	"errors"
 	"os"
 )
 
@@ -14,18 +14,21 @@ type Config struct {
 	AccessToken  string `json:"access_token"`
 }
 
-// LoadConfiguration loads all configuration that exists in
-// config.json and assigns it to a Config struct object
-func LoadConfiguration() Config {
-	configFile, err := os.Open("config/config.json")
+// LoadConfiguration loads the config file that is specified as a parameter and decodes
+// it into a Config struct object
+func LoadConfiguration(configPath string) (Config, error) {
+	configFile, err := os.Open(configPath)
 	defer configFile.Close()
 	if err != nil {
-		log.Println("error when opening config.json")
-		panic(err)
+		return Config{}, errors.New("Configuration loading failed: Error when opening config file: " + configPath + "\r\n" +
+			"Please check you have specified the correct path to the json file. Example: folder/config/config.json")
 	}
+
 	jsonParser := json.NewDecoder(configFile)
 
 	var config Config
-	jsonParser.Decode(&config)
-	return config
+	if jsonParser.Decode(&config) != nil {
+		return Config{}, errors.New("Configuration loading failed: Error decoding config.json file, please check it is valid json")
+	}
+	return config, nil
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,6 @@
 {
-    "organisation": "example",
-    "host": "example",
-    "port": "example",
+    "organisation": "ChrisJBurns",
+    "host": "localhost",
+    "port": "8000",
     "access_token": "example"
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,6 @@
 {
-    "organisation": "ChrisJBurns",
-    "host": "localhost",
-    "port": "8000",
+    "organisation": "example",
+    "host": "example",
+    "port": "example",
     "access_token": "example"
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestLoadConfigurationFailure(t *testing.T) {
+	_, err := LoadConfiguration("")
+	if err == nil {
+		t.Errorf("Test failed, expected an error when loading a invalid config file")
+	}
+}
+
+func TestLoadConfigurationSuccess(t *testing.T) {
+	_, err := LoadConfiguration("config.json")
+	if err != nil {
+		t.Errorf("Test failed, expected no error when loading a valid config file")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,21 +1,112 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/ChrisJBurns/label-hook/config"
 )
 
-func TestLoadConfig(t *testing.T) {
-	cfg = config.LoadConfiguration()
+func TestGetConfigurationPathWithTooLittleCommandArguments(t *testing.T) {
+	os.Args = []string{"first"}
 
-	if cfg == (config.Config{}) {
-		t.Error("Loading configuration failed: returned null")
+	_, err := GetConfigurationPath()
+	if err == nil {
+		t.Errorf("Test failed, expected to fail when no arguments are provided to application")
 	}
-	if cfg.Port == "" {
-		t.Error("Configured port is empty")
+}
+
+func TestGetConfigurationPathWithTooManyCommandArguments(t *testing.T) {
+	os.Args = []string{"first", "second", "third"}
+
+	_, err := GetConfigurationPath()
+	if err == nil {
+		t.Errorf("Test failed, expected to fail when too many arguments are provided to application")
 	}
-	if cfg.Host == "" {
-		t.Error("Configured host is empty")
+}
+
+func TestGetConfigurationPathWithCorrectNumberOfCommandArguments(t *testing.T) {
+	os.Args = []string{"first", "second"}
+
+	config, err := GetConfigurationPath()
+	if err != nil {
+		t.Errorf("Test failed, error returned from GetConfigurationPath with correct number of arguments")
+	}
+
+	if config == "" {
+		t.Errorf("Test failed, incorrect config path returned")
+	}
+}
+
+func TestLoadConfigurationFailure(t *testing.T) {
+	_, err := config.LoadConfiguration("")
+	if err == nil {
+		t.Errorf("Test failed, expected an error when loading a invalid config file")
+	}
+}
+
+func TestLoadConfigurationSuccess(t *testing.T) {
+	_, err := config.LoadConfiguration("config/config.json")
+	if err != nil {
+		t.Errorf("Test failed, expected no error when loading a valid config file")
+	}
+}
+
+func TestValidateConfigFailureEmptyConfig(t *testing.T) {
+	cfg := config.Config{}
+	if err := ValidateConfig(cfg); err == nil {
+		t.Errorf("Test failed, expected error when validating blank config struct")
+	}
+}
+
+func TestValidateConfigFailureNoOrganisation(t *testing.T) {
+	cfg := config.Config{Organisation: "",
+		Host:        "host",
+		Port:        "port",
+		AccessToken: "access_token"}
+
+	if err := ValidateConfig(cfg); err == nil {
+		t.Errorf("Test failed, expected error when validating blank organisation property")
+	}
+}
+
+func TestValidateConfigFailureNoHost(t *testing.T) {
+	cfg := config.Config{Organisation: "organisation",
+		Host:        "",
+		Port:        "port",
+		AccessToken: "access_token"}
+
+	if err := ValidateConfig(cfg); err == nil {
+		t.Errorf("Test failed, expected error when validating blank host property")
+	}
+}
+
+func TestValidateConfigFailureNoPort(t *testing.T) {
+	cfg := config.Config{Organisation: "organisation",
+		Host:        "host",
+		Port:        "",
+		AccessToken: "access_token"}
+
+	if err := ValidateConfig(cfg); err == nil {
+		t.Errorf("Test failed, expected error when validating blank port property")
+	}
+}
+
+func TestValidateConfigFailureNoAccessToken(t *testing.T) {
+	cfg := config.Config{Organisation: "organisation",
+		Host:        "host",
+		Port:        "port",
+		AccessToken: ""}
+
+	if err := ValidateConfig(cfg); err == nil {
+		t.Errorf("Test failed, expected error when validating blank access token property")
+	}
+}
+
+func TestCreateClient(t *testing.T) {
+	CreateClient()
+
+	if client == nil {
+		t.Errorf("Test failed, expected created github client")
 	}
 }


### PR DESCRIPTION
Before, the `config.json` file location was hardcoded in the code which made it difficult to test from both packages and additionally it meant that the user was forced into following the same `config.json` file structure. This has been changed so you can dynamically provide the location of the `config.json` file as an argument to the application. It has some additional checking that identifies if there's a correct path and whether it has successfully decoded the config into a code representation of that data.
Additionally the unit test coverage has now increased.

Resolves issue #6 and resolves #2 